### PR TITLE
add listmonk values

### DIFF
--- a/listmonk/values.yaml
+++ b/listmonk/values.yaml
@@ -1,0 +1,11 @@
+ingress:
+  enabled: true
+  host: listmonk.democracy-app.de
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: 'true'
+    cert-manager.io/cluster-issuer: 'letsencrypt-prod'
+  tls:
+    - hosts:
+        - listmonk.democracy-app.de
+      secretName: listmonk-tls


### PR DESCRIPTION
This pull request includes changes to the `listmonk/values.yaml` file to enable and configure ingress for the `listmonk` application.

Ingress configuration:

* [`listmonk/values.yaml`](diffhunk://#diff-1c977a513cb9eaba2e3209f30b3570d8884ff4eb48240296acc5c88dcacf088eR1-R11): Enabled ingress and set up the host, annotations, and TLS settings for the `listmonk` application.