### PR TITLE
chore(infrastructure): add MongoDB headless service and PodDisruption Budget for improved resilience

### DIFF
--- a/kustomize/overlays/production/yamls/kustomization.yaml
+++ b/kustomize/overlays/production/yamls/kustomization.yaml
@@ -7,6 +7,7 @@ patches:
   - path: democracy-api-depl.yaml
   - path: democracy-app-depl.yaml
   - path: gorush-depl.yaml
+  - path: mongo-headless-service.yaml
   - path: mongo-statefulset.yaml
   - path: queue-pushs-conference-week.yaml
   - path: queue-pushs-vote-conference-week.yaml
@@ -15,5 +16,6 @@ patches:
 resources:
   - ../../../base/cluster
   - ingress-srv.yaml
+  - mongo-pdb.yaml
 
 namespace: democracy-production

--- a/kustomize/overlays/production/yamls/mongo-headless-service.yaml
+++ b/kustomize/overlays/production/yamls/mongo-headless-service.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: mongo
+spec:
+  publishNotReadyAddresses: true
+  selector:
+    app: mongo
+    mongo-rs-role: active

--- a/kustomize/overlays/production/yamls/mongo-pdb.yaml
+++ b/kustomize/overlays/production/yamls/mongo-pdb.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: mongo-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app: mongo
+      mongo-rs-role: active

--- a/kustomize/overlays/production/yamls/mongo-statefulset.yaml
+++ b/kustomize/overlays/production/yamls/mongo-statefulset.yaml
@@ -7,12 +7,25 @@ spec:
     matchLabels:
       app: mongo
   serviceName: "mongo"
-  replicas: 5
+  replicas: 3
+  ordinals:
+    start: 3
+  updateStrategy:
+    type: OnDelete
   template:
     metadata:
       labels:
         app: mongo
+        mongo-rs-role: active
     spec:
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            - labelSelector:
+                matchLabels:
+                  app: mongo
+                  mongo-rs-role: active
+              topologyKey: kubernetes.io/hostname
       containers:
         - name: mongo
           command:


### PR DESCRIPTION
This pull request introduces several production Kubernetes configuration changes to improve the reliability and management of the MongoDB deployment. The main updates include reducing the number of MongoDB replicas, adding a PodDisruptionBudget, introducing a headless service, and enhancing pod scheduling and update strategies for better high availability.

**MongoDB StatefulSet improvements:**

* Reduced the number of MongoDB replicas from 5 to 3, set the StatefulSet to use `OnDelete` update strategy, added an affinity rule for pod anti-affinity, and labeled pods with `mongo-rs-role: active` to improve high availability and scheduling.

**New resources for MongoDB:**

* Added `mongo-pdb.yaml` to define a PodDisruptionBudget ensuring at least 2 MongoDB pods are always available during disruptions. [[1]](diffhunk://#diff-fc21deaa1d8c5bd08bd0862f0e515a392ed86cfc2413b30e386dc9c60b80931eR1-R10) [[2]](diffhunk://#diff-d1afdcd1223b3c30e6515475233a9976249eed270d630aeeb78b965d2750d228R19)
* Added `mongo-headless-service.yaml` to provide a headless service for MongoDB, enabling direct pod-to-pod communication required for StatefulSets. [[1]](diffhunk://#diff-9be4b845b32809bbd2a0a71dbe739e6b14ea774782fb60b7b4af2e25f280cdb5R1-R9) [[2]](diffhunk://#diff-d1afdcd1223b3c30e6515475233a9976249eed270d630aeeb78b965d2750d228R10)

**Configuration updates:**

* Updated `kustomization.yaml` to include the new headless service and PodDisruptionBudget resources in the production overlay. [[1]](diffhunk://#diff-d1afdcd1223b3c30e6515475233a9976249eed270d630aeeb78b965d2750d228R10) [[2]](diffhunk://#diff-d1afdcd1223b3c30e6515475233a9976249eed270d630aeeb78b965d2750d228R19)